### PR TITLE
Fix scatter points hidden by SVG after canvas switch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -634,16 +634,16 @@ const App = () => {
           {/* Fixed visualization container */}
           <div className="sticky top-0 w-full h-screen flex items-center justify-center">
             <div className="relative w-full h-screen">
-              <canvas
-                ref={canvasRef}
-                width={1200}
-                height={600}
-                className="absolute top-0 left-0 w-full h-full"
-              />
               <svg
                 ref={svgRef}
                 viewBox="0 0 1200 600"
                 preserveAspectRatio="xMidYMid meet"
+                className="absolute top-0 left-0 w-full h-full"
+              />
+              <canvas
+                ref={canvasRef}
+                width={1200}
+                height={600}
                 className="absolute top-0 left-0 w-full h-full bg-white rounded-lg shadow-lg"
               />
             </div>


### PR DESCRIPTION
## Summary
- layer the canvas on top of the SVG
- move white background to the canvas so points render

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869421c17388326afa43cdda5f5df6d