### PR TITLE
Fix Tailwind init ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,12 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Svelte</title>
+    <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {
         content: ["./index.html", "./src/**/*.{js,svelte,ts}"]
       };
     </script>
-    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body class="h-full">
     <div id="root" class="h-full">


### PR DESCRIPTION
## Summary
- load Tailwind CDN script before setting `tailwind.config`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd51ac74883269661bebdf1501175