### PR TITLE
Fix link copy button for embedded usage

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1529,13 +1529,8 @@
     
     // Check if we're in an iframe
     if (typeof window !== 'undefined' && window.parent !== window) {
-      // We're in an iframe - construct PolicyEngine URL
-      // First check if we're on policyengine.github.io (dev) or elsewhere
-      const isGitHubPages = window.location.hostname === 'policyengine.github.io';
-      const baseUrl = isGitHubPages 
-        ? 'https://policyengine.org/us/obbba-household-explorer'
-        : window.location.href;
-      url = new URL(baseUrl);
+      // We're in an iframe - always use PolicyEngine URL
+      url = new URL('https://policyengine.org/us/obbba-household-explorer');
     } else {
       // Not in iframe, use current location
       url = new URL(window.location.href);


### PR DESCRIPTION
## Description

Fixes #51 

This PR fixes the link copy button (🔗) to generate complete, shareable URLs when the OBBBA household explorer is embedded in PolicyEngine.

## Changes

- Modified `copyHouseholdUrl` function to detect iframe embedding
- When embedded, constructs full PolicyEngine URLs instead of partial URLs
- Ensures copied links work correctly when shared

## Testing

1. Visit https://policyengine.org/us/obbba-household-explorer
2. Navigate to any household view
3. Click the 🔗 button
4. Paste the clipboard contents - it should be a complete URL like:
   `https://policyengine.org/us/obbba-household-explorer?household=39033&baseline=tcja-expiration&section=lower-income-individual`