### PR TITLE
Add robust clipboard fallback using textarea method

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1576,14 +1576,46 @@
       
       console.log('Successfully copied URL to clipboard');
     } catch (err) {
-      console.error('Failed to copy URL:', err);
-      // Fallback: try to copy just the query string if full URL fails
+      console.error('Clipboard API failed:', err);
+      
+      // Fallback method: Create a temporary textarea
       try {
-        const fallbackUrl = url.search;
-        await navigator.clipboard.writeText(fallbackUrl);
-        console.log('Copied fallback URL (query string only):', fallbackUrl);
+        const textarea = document.createElement('textarea');
+        textarea.value = fullUrl;
+        textarea.style.position = 'fixed';
+        textarea.style.left = '-999999px';
+        textarea.style.top = '-999999px';
+        document.body.appendChild(textarea);
+        textarea.focus();
+        textarea.select();
+        
+        const successful = document.execCommand('copy');
+        document.body.removeChild(textarea);
+        
+        if (successful) {
+          console.log('Successfully copied using execCommand fallback');
+          
+          // Show success feedback
+          if (event && event.target) {
+            const button = event.target.closest('button');
+            if (button) {
+              const originalTitle = button.title;
+              button.title = 'Copied!';
+              button.classList.add('copied');
+              
+              setTimeout(() => {
+                button.title = originalTitle;
+                button.classList.remove('copied');
+              }, 2000);
+            }
+          }
+        } else {
+          console.error('execCommand copy failed');
+          alert('Failed to copy URL. URL is: ' + fullUrl);
+        }
       } catch (fallbackErr) {
-        console.error('Fallback copy also failed:', fallbackErr);
+        console.error('All copy methods failed:', fallbackErr);
+        alert('Failed to copy URL. URL is: ' + fullUrl);
       }
     }
   }


### PR DESCRIPTION
## Description

Fixes #51 (again)

The previous fix was merged but users reported the clipboard functionality still wasn't working. This PR adds a more robust fallback mechanism.

## Problem

When embedded in an iframe on PolicyEngine, the modern Clipboard API can fail due to:
- Browser security restrictions
- Permission denials
- Cross-origin iframe limitations

## Solution

This PR implements a multi-tier approach:

1. **Primary**: Try the modern Clipboard API
2. **Fallback**: If that fails, create a temporary textarea element and use the older `document.execCommand('copy')` method
3. **Last resort**: If both fail, show an alert with the URL so users can manually copy it

## Changes

- Replaced the simple query string fallback with a textarea-based copy method
- Added proper error handling for each tier
- Maintains visual feedback ("Copied\!" button state) for successful copies
- Logs detailed debug information to help diagnose issues

## Testing

1. Visit https://policyengine.org/us/obbba-household-explorer  
2. Open browser console (F12)
3. Navigate to any household
4. Click the 🔗 button
5. Check console for one of these outcomes:
   - "Successfully copied URL to clipboard" (primary method worked)
   - "Clipboard API failed" followed by "Successfully copied using execCommand fallback" (fallback worked)
   - Alert dialog with the URL (both methods failed)

The clipboard should now contain the full URL in all supported browsers and iframe contexts.