### PR TITLE
Refactor +page.svelte into smaller components (Part 1)

### DIFF
--- a/src/lib/components/DataTable.svelte
+++ b/src/lib/components/DataTable.svelte
@@ -1,0 +1,169 @@
+<script>
+  export let selectedData = null;
+  export let onClose = () => {};
+  
+  // Fields to exclude from display
+  const excludeFields = ['id', 'isAnnotated', 'sectionIndex', 'isHighlighted', 'highlightGroup', 'stateIndex', 'householdId'];
+  
+  function formatValue(key, value) {
+    if (typeof value === 'number') {
+      if (key.includes('Income') || key.includes('Taxes') || key.includes('Tax Liability') || 
+          key.includes('Benefits') || key.includes('Gains') || key.includes('Interest') || 
+          key.includes('Medicaid') || key.includes('ACA') || key.includes('CHIP') || 
+          key.includes('SNAP') || (key.toLowerCase().includes('change in') && !key.includes('Percentage'))) {
+        return (value < 0 ? '-' : '') + '$' + Math.abs(Math.round(value)).toLocaleString();
+      } else if (key.includes('Percentage')) {
+        return (value > 0 ? '+' : '') + value.toFixed(2) + '%';
+      } else if (key.includes('ID') || key.includes('Household')) {
+        return Math.round(value);
+      } else {
+        return Math.round(value).toLocaleString();
+      }
+    }
+    return value;
+  }
+</script>
+
+{#if selectedData}
+  <div class="data-table-overlay" on:click={onClose}>
+    <div class="data-table-container" on:click|stopPropagation>
+      <h3>Selected Household Data</h3>
+      <table class="data-table">
+        <tbody>
+          {#each Object.entries(selectedData) as [key, value], index}
+            {#if !excludeFields.includes(key)}
+              <tr>
+                <td class="key-column">{key}</td>
+                <td class="value-column">
+                  <span id="table-value-{index}">{formatValue(key, value)}</span>
+                </td>
+              </tr>
+            {/if}
+          {/each}
+        </tbody>
+      </table>
+      <button class="close-table" on:click={onClose}>×</button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  /* Data table styles */
+  .data-table-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.3);
+    z-index: 999;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding-bottom: 20px;
+  }
+
+  .data-table-container {
+    position: relative;
+    bottom: unset;
+    left: unset;
+    transform: unset;
+    background: var(--app-background);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    padding: 20px;
+    max-width: 500px;
+    max-height: 60vh;
+    overflow-y: auto;
+    z-index: 1000;
+  }
+
+  .data-table-container h3 {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0 0 15px 0;
+    padding-right: 30px;
+  }
+
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+
+  .data-table tr {
+    border-bottom: 1px solid var(--grid-lines);
+  }
+
+  .data-table tr:last-child {
+    border-bottom: none;
+  }
+
+  .key-column {
+    padding: 8px 12px 8px 0;
+    color: var(--text-secondary);
+    vertical-align: top;
+    font-weight: 500;
+    width: 60%;
+  }
+
+  .value-column {
+    padding: 8px 0;
+    color: var(--text-primary);
+    font-weight: 600;
+    text-align: right;
+  }
+
+  .close-table {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    color: var(--text-secondary);
+    cursor: pointer;
+    width: 25px;
+    height: 25px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    transition: background-color 0.2s;
+  }
+
+  .close-table:hover {
+    background-color: var(--hover);
+    color: var(--text-primary);
+  }
+
+  /* Mobile responsive for data table */
+  @media (max-width: 768px) {
+    .data-table-overlay {
+      align-items: flex-end;
+      padding-bottom: 0;
+    }
+
+    .data-table-container {
+      position: relative;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      width: 100%;
+      max-width: none;
+      border-radius: 8px 8px 0 0;
+      max-height: 50vh;
+    }
+
+    .data-table {
+      font-size: 11px;
+    }
+
+    .key-column {
+      padding: 6px 8px 6px 0;
+      width: 55%;
+    }
+  }
+</style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,0 +1,147 @@
+<script>
+  import { datasets } from '../config/datasets.js';
+  
+  export let selectedDataset = 'tcja-expiration';
+  export let loading = false;
+  export let onDatasetChange = () => {};
+</script>
+
+<header class="floating-header">
+  <div class="header-content">
+    <h1 class="app-title">OBBBA Household Explorer</h1>
+    <div class="baseline-selector-container">
+      <span class="baseline-label">Baseline:</span>
+      <div class="baseline-selector">
+        {#each Object.entries(datasets) as [key, dataset]}
+          <button 
+            class="tab-button" 
+            class:active={selectedDataset === key}
+            on:click={() => onDatasetChange(key)}
+            disabled={loading}
+          >
+            {dataset.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+  </div>
+</header>
+
+<style>
+  /* Floating header styles */
+  .floating-header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: var(--app-background);
+    border-bottom: 1px solid var(--border);
+    z-index: 100;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  }
+
+  .header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 24px;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+
+  .app-title {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0;
+  }
+
+  /* Baseline selector container */
+  .baseline-selector-container {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .baseline-label {
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--text-secondary);
+  }
+
+  /* Use sans-serif for UI elements */
+  .baseline-label,
+  .tab-button {
+    font-family: var(--font-sans);
+  }
+
+  /* Tabbed radio button styles */
+  .baseline-selector {
+    display: flex;
+    background: var(--grid-lines);
+    border-radius: 8px;
+    padding: 4px;
+    gap: 4px;
+  }
+
+  .tab-button {
+    background: transparent;
+    border: none;
+    color: var(--text-secondary);
+    font-size: 14px;
+    font-weight: 500;
+    padding: 8px 16px;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+  }
+
+  .tab-button:hover:not(:disabled):not(.active) {
+    background: rgba(44, 100, 150, 0.08);
+    color: var(--text-primary);
+  }
+
+  .tab-button.active {
+    background: var(--app-background);
+    color: var(--policyengine-blue);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
+  }
+
+  .tab-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* Mobile responsive header */
+  @media (max-width: 768px) {
+    .header-content {
+      padding: 12px 16px;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .app-title {
+      font-size: 20px;
+    }
+
+    .baseline-selector-container {
+      width: 100%;
+    }
+
+    .baseline-label {
+      font-size: 13px;
+    }
+
+    .baseline-selector {
+      flex: 1;
+      justify-content: center;
+    }
+
+    .tab-button {
+      flex: 1;
+      font-size: 13px;
+      padding: 6px 12px;
+    }
+  }
+</style>

--- a/src/lib/components/LoadingOverlay.svelte
+++ b/src/lib/components/LoadingOverlay.svelte
@@ -1,0 +1,50 @@
+<script>
+  export let dataset = { label: 'data' };
+</script>
+
+<div class="loading-overlay">
+  <div class="loading-content">
+    <div class="spinner"></div>
+    <p>Loading {dataset.label} data...</p>
+  </div>
+</div>
+
+<style>
+  .loading-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.95);
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .loading-content {
+    text-align: center;
+  }
+
+  .loading-content p {
+    font-size: 14px;
+    color: var(--text-secondary);
+    margin: 15px 0 0 0;
+  }
+
+  .spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid var(--light-gray);
+    border-top: 3px solid var(--text-secondary);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+    margin: 0 auto 20px;
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+</style>

--- a/src/lib/config/colors.js
+++ b/src/lib/config/colors.js
@@ -1,0 +1,46 @@
+// PolicyEngine Color Constants
+export const COLORS = {
+  BLACK: "#000000",
+  BLUE_98: "#F7FAFD",
+  BLUE: "#2C6496",
+  BLUE_LIGHT: "#D8E6F3",
+  BLUE_PRESSED: "#17354F",
+  DARK_BLUE_HOVER: "#1d3e5e",
+  DARK_GRAY: "#616161",
+  DARK_RED: "#b50d0d",
+  DARKEST_BLUE: "#0C1A27",
+  GRAY: "#808080",
+  LIGHT_GRAY: "#F2F2F2",
+  MEDIUM_DARK_GRAY: "#D2D2D2",
+  MEDIUM_LIGHT_GRAY: "#BDBDBD",
+  TEAL_ACCENT: "#39C6C0",
+  TEAL_LIGHT: "#F7FDFC",
+  TEAL_MEDIUM: "#2D9E99",
+  TEAL_PRESSED: "#227773",
+  WHITE: "#FFFFFF"
+};
+
+// Application Color Mappings
+export const APP_COLORS = {
+  background: COLORS.WHITE,
+  textPrimary: COLORS.DARKEST_BLUE,
+  textSecondary: COLORS.DARK_GRAY,
+  axisGrid: COLORS.BLACK,
+  gridLines: COLORS.MEDIUM_DARK_GRAY,
+  scatterPositive: COLORS.TEAL_MEDIUM,
+  scatterNegative: COLORS.DARK_GRAY,
+  scatterNeutral: COLORS.MEDIUM_DARK_GRAY,
+  border: COLORS.MEDIUM_DARK_GRAY,
+  hover: COLORS.BLUE_98
+};
+
+// Get color for data point based on change value
+export function getPointColor(change) {
+  if (Math.abs(change) < 0.1) {
+    return APP_COLORS.scatterNeutral;
+  } else if (change > 0) {
+    return APP_COLORS.scatterPositive;
+  } else {
+    return APP_COLORS.scatterNegative;
+  }
+}

--- a/src/lib/config/datasets.js
+++ b/src/lib/config/datasets.js
@@ -1,0 +1,15 @@
+// Dataset configuration
+export const datasets = {
+  'tcja-expiration': {
+    filename: 'household_tax_income_changes_senate_current_law_baseline.csv',
+    label: 'TCJA Expiration',
+    description: 'Analysis showing impact if TCJA provisions expire'
+  },
+  'tcja-extension': {
+    filename: 'household_tax_income_changes_senate_tcja_baseline.csv',
+    label: 'TCJA Extension',
+    description: 'Analysis showing impact if TCJA provisions are extended'
+  }
+};
+
+export const defaultDataset = 'tcja-expiration';

--- a/src/lib/config/views.js
+++ b/src/lib/config/views.js
@@ -1,0 +1,87 @@
+// Base view configurations for scroll states
+export const baseViews = [
+  {
+    id: 'intro',
+    title: "How tax changes affect every American household",
+    groupText: "Each dot represents a household, positioned by their income and how much they gain or lose under the proposed tax changes. Green dots show households that benefit, red shows those that face increases.",
+    view: {
+      xDomain: [-15, 15],
+      yDomain: [0, 350000],
+      filter: d => d['Gross Income'] < 350000,
+      highlightGroup: null
+    }
+  },
+  {
+    id: 'lower-income', 
+    title: "Lower-income households under $50,000",
+    groupText: "Households earning under $50,000 see varied outcomes. While many benefit from Child Tax Credit expansions and TCJA extensions, some undocumented families lose access to credits due to new SSN requirements. Individuals in the bottom decile will gain an average of $213, while the top decile will gain an average of $13,075.",
+    view: {
+      xDomain: [-15, 15],
+      yDomain: [0, 50000],
+      filter: d => d['Gross Income'] >= 0 && d['Gross Income'] < 50000,
+      highlightGroup: 'lower'
+    }
+  },
+  {
+    id: 'middle-income',
+    title: "Middle-income households ($50,000 - $200,000)", 
+    groupText: "This broad middle class benefits significantly from TCJA extensions, enhanced Child Tax Credits, and new deductions for tips and overtime pay. Seniors in this range gain substantially from the additional $6,000 senior deduction. These households typically see Net Income increases from the tax provisions.",
+    view: {
+      xDomain: [-25, 25],
+      yDomain: [50000, 200000],
+      filter: d => d['Gross Income'] >= 50000 && d['Gross Income'] < 200000,
+      highlightGroup: 'middle'
+    }
+  },
+  {
+    id: 'upper-income',
+    title: "Upper-income households ($200,000 - $1 million)",
+    groupText: "Higher-income households generally benefit the most in dollar terms from TCJA extensions. Rate reductions, business income deductions, and estate tax reforms provide substantial savings. However, some face increases due to SALT limitations and other targeted provisions.",
+    view: {
+      xDomain: [-40, 60],
+      yDomain: [200000, 1000000],
+      filter: d => d['Gross Income'] >= 200000 && d['Gross Income'] < 1000000,
+      highlightGroup: 'upper'
+    }
+  },
+  {
+    id: 'highest-income',
+    title: "The highest-income households (over $1 million)",
+    groupText: "The wealthiest Americans see the largest absolute gains from these tax changes. Estate tax reforms, business income deductions, and rate cuts combine to provide significant benefits, though SALT caps and other provisions create some variation in outcomes.",
+    view: {
+      xDomain: [-50, 300],
+      yDomain: [1000000, 10000000],
+      filter: d => d['Gross Income'] >= 1000000,
+      highlightGroup: 'highest'
+    }
+  }
+];
+
+// Generate scroll states from base views (group + individual views)
+export function generateScrollStates() {
+  const scrollStates = [];
+  
+  baseViews.forEach((baseView, baseIndex) => {
+    // Add group view
+    scrollStates.push({
+      id: baseView.id,
+      ...baseView.view,
+      title: baseView.title,
+      text: baseView.groupText,
+      viewType: 'group'
+    });
+    
+    // Add individual view (except for intro)
+    if (baseIndex > 0) {
+      scrollStates.push({
+        id: baseView.id + '-individual',
+        ...baseView.view,
+        title: baseView.title + ' — individual profile',
+        text: 'Meet a specific household affected by these changes.',
+        viewType: 'individual'
+      });
+    }
+  });
+  
+  return scrollStates;
+}

--- a/src/lib/data/dataLoader.js
+++ b/src/lib/data/dataLoader.js
@@ -1,0 +1,56 @@
+import Papa from 'papaparse';
+import { datasets } from '../config/datasets.js';
+
+// Load dataset from CSV file
+export async function loadDataset(datasetKey) {
+  const dataset = datasets[datasetKey];
+  if (!dataset) {
+    throw new Error(`Unknown dataset: ${datasetKey}`);
+  }
+
+  try {
+    const response = await fetch(`/obbba-scatter/${dataset.filename}`);
+    if (!response.ok) {
+      throw new Error(`Failed to load CSV: ${response.status} ${response.statusText}`);
+    }
+    
+    const raw = await response.text();
+    const result = Papa.parse(raw, {
+      header: true,
+      dynamicTyping: true,
+      skipEmptyLines: true
+    });
+    
+    if (result.errors.length > 0) {
+      console.warn('CSV parsing warnings:', result.errors);
+    }
+    
+    return result.data;
+  } catch (error) {
+    console.error('Error loading data:', error);
+    console.error('Dataset key:', datasetKey);
+    console.error('Filename:', dataset?.filename);
+    console.error('Full URL:', `/obbba-scatter/${dataset?.filename}`);
+    throw error;
+  }
+}
+
+// Process raw data into usable format
+export function processData(rawData) {
+  return rawData.map((d, i) => ({
+    ...d,
+    id: String(d['Household ID'] || i), // Convert to string for consistent comparison
+    householdId: d['Household ID'], // Keep original for reference
+    isAnnotated: false,
+    sectionIndex: null
+  }));
+}
+
+// Build household ID map for quick lookups
+export function buildHouseholdMap(data) {
+  const householdIdMap = new Map();
+  data.forEach(household => {
+    householdIdMap.set(household.id, household);
+  });
+  return householdIdMap;
+}

--- a/src/lib/utils/clipboard.js
+++ b/src/lib/utils/clipboard.js
@@ -1,0 +1,102 @@
+// Copy household URL to clipboard with fallback methods
+export async function copyHouseholdUrl(household, selectedDataset, currentState, event) {
+  let url;
+  
+  // Debug logging to understand the issue
+  const isInIframe = typeof window !== 'undefined' && window.parent !== window;
+  console.log('Copy URL debug:', {
+    isInIframe,
+    currentLocation: window.location.href,
+    household: household.id,
+    baseline: selectedDataset,
+    section: currentState?.id
+  });
+  
+  // Check if we're in an iframe
+  if (isInIframe) {
+    // We're in an iframe - always use PolicyEngine URL
+    url = new URL('https://policyengine.org/us/obbba-household-explorer');
+  } else {
+    // Not in iframe, use current location
+    url = new URL(window.location.href);
+  }
+  
+  // Set household parameters
+  url.searchParams.set('household', household.id);
+  url.searchParams.set('baseline', selectedDataset);
+  if (currentState) {
+    url.searchParams.set('section', currentState.id);
+  }
+  
+  const fullUrl = url.toString();
+  console.log('Full URL to copy:', fullUrl);
+  
+  try {
+    // Try to use the Clipboard API
+    await navigator.clipboard.writeText(fullUrl);
+    console.log('Successfully copied URL to clipboard');
+    
+    // Show temporary success feedback
+    if (event && event.target) {
+      const button = event.target.closest('button');
+      if (button) {
+        const originalTitle = button.title;
+        button.title = 'Copied!';
+        button.classList.add('copied');
+        
+        setTimeout(() => {
+          button.title = originalTitle;
+          button.classList.remove('copied');
+        }, 2000);
+      }
+    }
+    
+    return true;
+  } catch (err) {
+    console.error('Clipboard API failed:', err);
+    
+    // Fallback method: Create a temporary textarea
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = fullUrl;
+      textarea.style.position = 'fixed';
+      textarea.style.left = '-999999px';
+      textarea.style.top = '-999999px';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      
+      const successful = document.execCommand('copy');
+      document.body.removeChild(textarea);
+      
+      if (successful) {
+        console.log('Successfully copied using execCommand fallback');
+        
+        // Show success feedback
+        if (event && event.target) {
+          const button = event.target.closest('button');
+          if (button) {
+            const originalTitle = button.title;
+            button.title = 'Copied!';
+            button.classList.add('copied');
+            
+            setTimeout(() => {
+              button.title = originalTitle;
+              button.classList.remove('copied');
+            }, 2000);
+          }
+        }
+        
+        return true;
+      } else {
+        console.error('execCommand copy failed');
+        alert('Failed to copy URL. URL is: ' + fullUrl);
+        return false;
+      }
+    } catch (fallbackErr) {
+      console.error('All copy methods failed:', fallbackErr);
+      alert('Failed to copy URL. URL is: ' + fullUrl);
+      return false;
+    }
+  }
+}

--- a/src/lib/utils/formatting.js
+++ b/src/lib/utils/formatting.js
@@ -1,0 +1,37 @@
+// Consistent number formatters
+export const fmtUSD = new Intl.NumberFormat('en-US', { 
+  style: 'currency', 
+  currency: 'USD', 
+  maximumFractionDigits: 0 
+});
+
+export const fmtPct = new Intl.NumberFormat('en-US', { 
+  style: 'percent', 
+  minimumFractionDigits: 1, 
+  maximumFractionDigits: 1 
+});
+
+// Formatting functions
+export function formatCurrency(value) {
+  return fmtUSD.format(Math.round(value));
+}
+
+export function formatPercentage(value) {
+  const formatted = fmtPct.format(value / 100); // Convert to decimal for Intl formatter
+  return value >= 0 ? '+' + formatted : formatted;
+}
+
+export function formatDollarChange(value) {
+  const formatted = fmtUSD.format(Math.abs(Math.round(value)));
+  return value >= 0 ? '+' + formatted : '-' + formatted;
+}
+
+// Get font family from type
+export function getFontFamily(type = 'sans') {
+  const fontMap = {
+    'serif': "'Roboto Serif', serif",
+    'sans': "'Roboto', sans-serif",
+    'mono': "'Roboto Mono', monospace"
+  };
+  return fontMap[type] || fontMap['sans'];
+}


### PR DESCRIPTION
## Description

This PR begins the refactoring of the 2,587-line `+page.svelte` file into smaller, more maintainable components as outlined in #55.

## Changes in Part 1

Created initial component structure:

### 📁 Components Created
- **lib/components/**
  - `Header.svelte` - Floating header with baseline selector
  - `DataTable.svelte` - Selected household data table  
  - `LoadingOverlay.svelte` - Loading state component

### 🎨 Configuration Files
- **lib/config/**
  - `colors.js` - PolicyEngine color constants and mappings
  - `datasets.js` - Dataset configurations
  - `views.js` - Scroll state and view definitions

### 🔧 Utilities
- **lib/utils/**
  - `clipboard.js` - URL copying functionality with fallbacks
  - `formatting.js` - Currency and percentage formatters

### 📊 Data Management  
- **lib/data/**
  - `dataLoader.js` - CSV loading and data processing

## What's Next (Part 2)

- [ ] Create visualization components (ScatterPlot, ChartCanvas, ChartAxes)
- [ ] Extract scroll handling logic
- [ ] Extract URL synchronization logic  
- [ ] Create HouseholdProfile component
- [ ] Update +page.svelte to use all new components
- [ ] Reduce +page.svelte from 2,587 to < 500 lines

## Testing

All functionality remains unchanged. The new components are ready to be integrated but the main page still works as before.

## Benefits So Far

- Clear separation of concerns
- Reusable utility functions
- Consistent color and formatting across the app
- Foundation for further refactoring

Part of #55