### PR TITLE
Fix deep link functionality for household URLs

### DIFF
--- a/src/lib/utils/clipboard.js
+++ b/src/lib/utils/clipboard.js
@@ -29,9 +29,6 @@ export async function copyHouseholdUrl(household, selectedDataset, currentState,
   // Set household parameters
   url.searchParams.set('household', household.id);
   url.searchParams.set('baseline', selectedDataset);
-  if (currentState) {
-    url.searchParams.set('section', currentState.id);
-  }
   
   const fullUrl = url.toString();
   console.log('Full URL to copy:', fullUrl);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -339,6 +339,12 @@
         // Find appropriate section
         const targetIndex = findSectionForHousehold(household, scrollStates);
         
+        // Update the random household for the appropriate section
+        const baseViewId = scrollStates[targetIndex]?.id?.replace('-individual', '') || scrollStates[targetIndex]?.id;
+        if (baseViewId) {
+          randomHouseholds[baseViewId] = household;
+        }
+        
         // Scroll to section
         if (textSections[targetIndex] && scrollContainer) {
           // Delay to ensure DOM is ready


### PR DESCRIPTION
## Summary

This PR fixes the deep link functionality that was broken when using the 🔗 button to copy household URLs.

## Problem

When users clicked the link button to copy a household URL, the copied link didn't properly restore the view state when opened in a new tab. The household wasn't being set as the random household for its income section.

## Solution

1. **Simplified URL structure** - Removed the unnecessary `section` parameter since the section can be automatically determined from the household's income
2. **Fixed household restoration** - When loading from URL params, the household is now properly set as the random household for the appropriate income section
3. **Maintained auto-scrolling** - The app still automatically scrolls to the correct section based on household income

## Testing

1. Navigate to any household in the app
2. Click the 🔗 button to copy the link
3. Open a new browser tab and paste the URL
4. ✅ The app should load with the correct household selected and scroll to the appropriate section

Fixes #60

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>