### PR TITLE
Fix scroll behavior when randomizing household in embedded view

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -195,7 +195,7 @@
   }
   
   // Handle household selection
-  function selectHousehold(household) {
+  function selectHousehold(household, shouldScroll = true) {
     selectedHousehold = household;
     
     // If we're in a group view, update the random household for that section
@@ -204,12 +204,15 @@
       // Update the random household for this section
       randomHouseholds[currentState.id] = household;
       
-      // Find the next individual view and scroll to it
-      const nextIndex = $currentStateIndex + 1;
-      if (scrollStates[nextIndex] && scrollStates[nextIndex].viewType === 'individual') {
-        // Scroll to the individual view
-        if (textSections[nextIndex]) {
-          textSections[nextIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
+      // Only scroll if explicitly requested (not when randomizing)
+      if (shouldScroll) {
+        // Find the next individual view and scroll to it
+        const nextIndex = $currentStateIndex + 1;
+        if (scrollStates[nextIndex] && scrollStates[nextIndex].viewType === 'individual') {
+          // Scroll to the individual view
+          if (textSections[nextIndex]) {
+            textSections[nextIndex].scrollIntoView({ behavior: 'smooth', block: 'center' });
+          }
         }
       }
     } else if (currentState && currentState.viewType === 'individual') {
@@ -252,7 +255,7 @@
       
       if (newHousehold) {
         randomHouseholds[baseViewId] = newHousehold;
-        selectHousehold(newHousehold);
+        selectHousehold(newHousehold, false); // Don't scroll when randomizing
         
         // Re-trigger animations
         const sectionIndex = Math.floor($currentStateIndex / 2);


### PR DESCRIPTION
## Summary
This PR fixes an issue where clicking the shuffle/randomize button would cause the page to scroll down, making the baseline selector inaccessible in embedded iframe contexts.

## Problem
When users clicked the randomize button (🔀) in the household profile:
- The page would automatically scroll down to show an individual household view
- In embedded iframes (like on policyengine.org), this would push the header and baseline selector out of view
- Users couldn't access the baseline selector without scrolling back up

## Solution
- Added an optional `shouldScroll` parameter to the `selectHousehold` function (defaults to `true` to preserve existing behavior)
- When `randomizeHousehold` calls `selectHousehold`, it now passes `false` to prevent scrolling
- This maintains the scroll behavior for actual household clicks while preventing it during randomization

## Testing
- Tested randomizing households at various scroll positions
- Verified baseline selector remains accessible after randomization
- Confirmed clicking on scatter plot points still scrolls as expected
- Tested in both standalone and embedded iframe contexts

## Impact
This improves the user experience, especially in embedded contexts where the visualization is shown in an iframe with limited viewport height. Users can now freely randomize households without losing access to important controls.

🤖 Generated with [Claude Code](https://claude.ai/code)