### PR TITLE
Fix baseline values not updating when switching datasets

### DIFF
--- a/src/lib/components/HouseholdProfile.svelte
+++ b/src/lib/components/HouseholdProfile.svelte
@@ -61,10 +61,22 @@
   });
   
   let previousHouseholdId = null;
+  let previousDataset = null;
   
-  // Update animated values when household changes
-  $: if (household && household.id !== previousHouseholdId) {
+  // Update animated values when household changes or dataset changes
+  $: if (household && (household.id !== previousHouseholdId || selectedDataset !== previousDataset)) {
+    console.log('HouseholdProfile updating:', {
+      householdId: household.id,
+      dataset: selectedDataset,
+      netChange: household['Total Change in Net Income'] || household['Change in Household Net Income'],
+      percentChange: household['Percentage Change in Net Income'],
+      baselineNetIncome: household['Baseline Net Income'],
+      marketIncome: household['Market Income'] || household['Gross Income'],
+      allKeys: Object.keys(household).filter(k => k.includes('Income') || k.includes('Net'))
+    });
+    
     previousHouseholdId = household.id;
+    previousDataset = selectedDataset;
     
     // If this is the first household, start from random values for dramatic effect
     if ($householdId === 0) {


### PR DESCRIPTION
## Summary
- Fixes issue where household values weren't updating when switching between TCJA expiration and extension baselines
- Adds dataset tracking to HouseholdProfile component to trigger reactive updates
- Includes extensive debugging to diagnose data differences in production

## Technical Details
The issue was that the HouseholdProfile component only tracked household ID changes, not dataset changes. When switching baselines, the same household ID would have different values but the component wouldn't update.

### Changes Made:
1. Added `previousDataset` tracking in HouseholdProfile.svelte
2. Modified the reactive statement to trigger on both household ID and dataset changes
3. Added comprehensive debugging to verify data differences between datasets
4. Fixed timing of selectedDataset assignment to ensure proper logging

## Test Plan
1. Load the app with a specific household
2. Switch between TCJA expiration and extension baselines
3. Verify that the household's net income values update correctly
4. Check console logs to confirm data differences are being detected

Fixes #74

🤖 Generated with [Claude Code](https://claude.ai/code)