### PR TITLE
Add debounced scroll handler to prevent vibration

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -204,11 +204,18 @@
       // Save current scroll position
       const savedScrollTop = scrollContainer.scrollTop;
       
-      // Create a scroll handler that maintains position
+      // Use a debounced scroll handler to avoid vibration
+      let scrollTimeout;
       const maintainScroll = (e) => {
-        if (scrollContainer.scrollTop !== savedScrollTop) {
-          scrollContainer.scrollTop = savedScrollTop;
-        }
+        // Clear any pending position restore
+        clearTimeout(scrollTimeout);
+        
+        // Restore position after a tiny delay to avoid fighting with browser
+        scrollTimeout = setTimeout(() => {
+          if (scrollContainer && Math.abs(scrollContainer.scrollTop - savedScrollTop) > 1) {
+            scrollContainer.scrollTop = savedScrollTop;
+          }
+        }, 10);
       };
       
       // Add scroll listener to maintain position
@@ -216,6 +223,7 @@
       
       // Remove listener after animations complete
       setTimeout(() => {
+        clearTimeout(scrollTimeout);
         scrollContainer.removeEventListener('scroll', maintainScroll);
       }, 1000); // Match the longest animation duration
     }


### PR DESCRIPTION
This PR adds a debounced scroll handler to fix the tiny vibration when changing households.

## Problem
The scroll event handler was continuously fighting with the browser, causing a vibration effect.

## Solution
- Add 10ms setTimeout before restoring scroll position
- Only restore if scroll changed by more than 1px
- Clear pending timeouts to avoid accumulation

This prevents the continuous back-and-forth that causes vibration.