### PR TITLE
Prevent text selection in household profile

### DIFF
--- a/src/lib/components/HouseholdProfile.svelte
+++ b/src/lib/components/HouseholdProfile.svelte
@@ -382,6 +382,8 @@
     /* Prevent layout shifts during animations */
     contain: layout style;
     will-change: contents;
+    /* Prevent text selection during updates to avoid focus issues */
+    user-select: none;
   }
 
   .household-profile h3 {


### PR DESCRIPTION
This PR prevents text selection in the household profile component to avoid focus-related scrolling issues.

## Problem
When rapidly clicking the shuffle button or household values, text could get selected which sometimes triggers browser scroll behavior.

## Solution
- Add `user-select: none` CSS property to the household profile
- This prevents accidental text selection during interactions

## Benefits
- Eliminates one potential cause of unwanted scrolling
- Improves user experience when rapidly clicking
- Simple CSS-only solution

This is a small but useful improvement that complements the other scroll fixes.