### PR TITLE
Use event capture and preventDefault for scroll blocking

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -206,17 +206,21 @@
       
       // Create a scroll handler that maintains position
       const maintainScroll = (e) => {
+        // Cancel the event to prevent scrolling
+        e.preventDefault();
+        e.stopPropagation();
+        
         if (scrollContainer.scrollTop !== savedScrollTop) {
           scrollContainer.scrollTop = savedScrollTop;
         }
       };
       
-      // Add scroll listener to maintain position
-      scrollContainer.addEventListener('scroll', maintainScroll, { passive: false });
+      // Add scroll listener with capture to intercept early
+      scrollContainer.addEventListener('scroll', maintainScroll, { capture: true, passive: false });
       
       // Remove listener after animations complete
       setTimeout(() => {
-        scrollContainer.removeEventListener('scroll', maintainScroll);
+        scrollContainer.removeEventListener('scroll', maintainScroll, { capture: true });
       }, 1000); // Match the longest animation duration
     }
     


### PR DESCRIPTION
This PR enhances the scroll prevention by using event capture and preventDefault.

## Changes
- Add `capture: true` to addEventListener to intercept scroll events early
- Add `preventDefault()` and `stopPropagation()` to cancel scroll events
- Ensure removeEventListener also uses capture flag for proper cleanup

## Benefits
- More aggressive scroll prevention
- Intercepts scroll events before they bubble up
- Prevents default browser scroll behavior

This approach provides stronger scroll blocking during household changes.