### PR TITLE
Add Python cache files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ dist-ssr
 build/
 /build
 
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.pyc
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
This PR adds Python cache files to .gitignore to prevent them from being committed.

## Changes
- Add `__pycache__/` directory
- Add compiled Python files (`*.pyc`, `*.pyo`, `*.pyd`)
- Add Python class files (`*.class`)

This prevents Python bytecode files from being accidentally committed to the repository.