### PR TITLE
Simplify loading message

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -747,7 +747,7 @@
   </div>
   
   {#if isLoading}
-    <LoadingOverlay message="Loading tax impact data..." />
+    <LoadingOverlay message="Loading data..." />
   {/if}
   
   {#if loadError}


### PR DESCRIPTION
This PR simplifies the loading overlay message.

## Change
- Changed from "Loading tax impact data..." to "Loading data..."

## Reason
- More generic and concise
- The app loads various types of data, not just tax impact data
- Cleaner user experience