### PR TITLE
Remove header and implement title/baseline overlays

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1148,7 +1148,7 @@
     padding: 2rem 3rem 50vh 3rem;
     padding-left: calc(120px + 3rem); /* Space for y-axis - matches chart margin */
     padding-right: calc(120px + 3rem); /* Match left side for symmetry */
-    margin-top: 4rem; /* Normal spacing since title overlay is smaller */
+    margin-top: 25vh; /* Push content down so second box appears centered */
     width: 100%;
     position: relative;
   }
@@ -1225,6 +1225,7 @@
     max-width: 640px;
     width: 100%;
   }
+  
   
   /* Centered sections (intro and all-households) */
   .text-section.centered {
@@ -1427,6 +1428,7 @@
       margin-right: auto !important;
     }
     
+    
     .text-section h2 {
       font-size: 1.25rem;
       line-height: 1.3;
@@ -1492,6 +1494,7 @@
       padding: 0.875rem;
       margin-bottom: 50vh;
     }
+    
     
     .text-section h2 {
       font-size: 1.125rem;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -32,6 +32,7 @@
   let loadError = null;
   let selectedDataset = 'tcja-expiration';
   let secondDatasetLoading = false; // Track background loading
+  let baselineDropdownOpen = false; // Track dropdown state on mobile
   
   // Random households for each section
   let randomHouseholds = {};
@@ -571,6 +572,16 @@
     window.addEventListener('error', handleError);
     window.addEventListener('unhandledrejection', handleError);
     
+    // Handle clicks outside dropdown to close it
+    const handleClickOutside = (event) => {
+      const selector = event.target.closest('.baseline-selector-overlay');
+      if (!selector && baselineDropdownOpen) {
+        baselineDropdownOpen = false;
+      }
+    };
+    
+    window.addEventListener('click', handleClickOutside);
+    
     // Check if we're in an iframe and get URL params from parent if needed
     const isInIframe = window.self !== window.top;
     
@@ -761,6 +772,7 @@
       window.removeEventListener('mouseup', endDrag);
       window.removeEventListener('error', handleError);
       window.removeEventListener('unhandledrejection', handleError);
+      window.removeEventListener('click', handleClickOutside);
       cleanupScrollObserver(scrollObserver);
       cleanupAnimations();
     };
@@ -800,14 +812,28 @@
   </div>
   
   <!-- Baseline selector overlay (always visible on right) -->
-  <div class="baseline-selector-overlay">
-    <span class="baseline-label">Baseline:</span>
+  <div class="baseline-selector-overlay" class:dropdown-open={baselineDropdownOpen}>
+    <div class="baseline-selector-header">
+      <span class="baseline-label">Baseline:</span>
+      <button 
+        class="baseline-dropdown-toggle"
+        on:click={() => baselineDropdownOpen = !baselineDropdownOpen}
+      >
+        <span class="selected-baseline">{DATASETS[selectedDataset].label}</span>
+        <svg class="dropdown-arrow" width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M3 4.5L6 7.5L9 4.5"/>
+        </svg>
+      </button>
+    </div>
     <div class="baseline-selector">
       {#each Object.entries(DATASETS) as [key, dataset]}
         <button 
           class="tab-button" 
           class:active={selectedDataset === key}
-          on:click={() => handleDatasetChange(key)}
+          on:click={() => {
+            handleDatasetChange(key);
+            baselineDropdownOpen = false;
+          }}
           disabled={isLoading || (key === 'tcja-extension' && secondDatasetLoading && !allDatasets['tcja-extension'])}
         >
           {dataset.label}
@@ -1054,6 +1080,12 @@
     font-weight: 500;
     color: var(--text-secondary);
     font-family: var(--font-sans);
+  }
+  
+  /* Hide dropdown elements on desktop */
+  .baseline-selector-header,
+  .baseline-dropdown-toggle {
+    display: none;
   }
 
   .baseline-selector {
@@ -1390,24 +1422,88 @@
     }
     
     .baseline-selector-overlay {
-      top: 1rem;
+      top: auto;
+      bottom: 1rem;
       right: 1rem;
-      padding: 0.5rem 0.75rem;
+      padding: 0;
+      gap: 0;
+      flex-direction: column;
+      align-items: stretch;
+      background: transparent;
+      box-shadow: none;
+      border: none;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+    }
+    
+    /* Show dropdown elements on mobile */
+    .baseline-selector-header {
+      display: flex;
+      align-items: center;
       gap: 8px;
+      padding: 0.5rem 0.75rem;
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 12px;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+      border: 1px solid rgba(226, 232, 240, 0.5);
+    }
+    
+    .baseline-dropdown-toggle {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: none;
+      border: none;
+      padding: 0;
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--text-primary);
+      cursor: pointer;
+      font-family: var(--font-sans);
+    }
+    
+    .dropdown-arrow {
+      transition: transform 0.2s ease;
+    }
+    
+    .baseline-selector-overlay.dropdown-open .dropdown-arrow {
+      transform: rotate(180deg);
     }
     
     .baseline-label {
       font-size: 12px;
     }
     
+    /* Dropdown menu on mobile */
     .baseline-selector {
-      padding: 3px;
-      gap: 3px;
+      display: none;
+      position: absolute;
+      bottom: 100%;
+      right: 0;
+      margin-bottom: 8px;
+      padding: 8px;
+      flex-direction: column;
+      gap: 4px;
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 12px;
+      backdrop-filter: blur(8px);
+      -webkit-backdrop-filter: blur(8px);
+      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+      border: 1px solid rgba(226, 232, 240, 0.5);
+      min-width: 200px;
+    }
+    
+    .baseline-selector-overlay.dropdown-open .baseline-selector {
+      display: flex;
     }
     
     .tab-button {
       font-size: 12px;
-      padding: 6px 12px;
+      padding: 8px 12px;
+      text-align: left;
+      border-radius: 6px;
     }
     
     .text-content {
@@ -1471,18 +1567,29 @@
     }
     
     .baseline-selector-overlay {
-      top: 0.5rem;
+      bottom: 0.5rem;
       right: 0.5rem;
+    }
+    
+    .baseline-selector-header {
       padding: 0.375rem 0.5rem;
+    }
+    
+    .baseline-dropdown-toggle {
+      font-size: 11px;
     }
     
     .baseline-label {
       font-size: 11px;
     }
     
+    .baseline-selector {
+      padding: 6px;
+    }
+    
     .tab-button {
       font-size: 11px;
-      padding: 4px 8px;
+      padding: 6px 10px;
     }
     
     .text-content {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1476,6 +1476,11 @@
       font-size: 12px;
     }
     
+    /* Hide desktop label on mobile */
+    .baseline-selector-overlay > .baseline-label {
+      display: none;
+    }
+    
     /* Dropdown menu on mobile */
     .baseline-selector {
       display: none;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -838,10 +838,17 @@
           >
             <div class="section-content">
               <div class="drag-handle" title="Drag to move">⋮⋮</div>
-              <h2>{state.title}</h2>
+              {#if state.id !== 'intro'}
+                <h2>{state.title}</h2>
+              {/if}
               
+              <!-- Intro section content -->
+              {#if state.id === 'intro'}
+                {#if state.description}
+                  <p>{@html state.description}</p>
+                {/if}
               <!-- Dynamic content for income sections -->
-              {#if state.id !== 'intro' && data.length > 0}
+              {:else if data.length > 0}
                 {@const sectionData = data.filter(d => state.filter(d))}
                 {@const stats = calculateSectionStats(sectionData, false, state.id)}
                 {#if stats}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -794,18 +794,9 @@
     />
   </div>
   
-  <!-- Title overlay (always visible, content fades based on scroll) -->
+  <!-- Title overlay (always visible) -->
   <div class="title-overlay">
     <h1 class="overlay-title">{scrollStates[0]?.title || "The One Big Beautiful Bill Act, household by household"}</h1>
-    <div class="overlay-description" style="opacity: {$currentStateIndex === 0 ? 1 : 0}; transition: opacity 0.3s ease">
-      {#if scrollStates[0]?.description}
-        <p>{@html scrollStates[0].description}</p>
-      {/if}
-      <div class="scroll-indicator">
-        <span>Scroll to explore</span>
-        <span class="arrow">↓</span>
-      </div>
-    </div>
   </div>
   
   <!-- Baseline selector overlay (always visible on right) -->
@@ -832,12 +823,12 @@
   <div class="content-overlay" bind:this={scrollContainer}>
     <div class="text-content">
       {#each scrollStates as state, i}
-        {#if state.viewType === 'group' && state.id !== 'intro'}
+        {#if state.viewType === 'group'}
           <section 
             class="text-section {state.id}"
             class:active={$currentStateIndex === i}
             class:dragging={draggingSectionIndex === i}
-            class:centered={state.id === 'all-households'}
+            class:centered={state.id === 'intro' || state.id === 'all-households'}
             class:align-left={startOnLeft ? ['lower-income', 'upper-income'].includes(state.id) : ['middle-income', 'highest-income'].includes(state.id)}
             class:align-right={startOnLeft ? ['middle-income', 'highest-income'].includes(state.id) : ['lower-income', 'upper-income'].includes(state.id)}
             data-index={i}
@@ -992,41 +983,29 @@
     top: 0;
   }
   
-  /* Title overlay - always visible, full width */
+  /* Title overlay - always visible, centered */
   .title-overlay {
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
+    top: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 20; /* Higher than content overlay (15) to be above boxes */
-    background: rgba(255, 255, 255, 0.98);
-    padding: 1.5rem 2rem;
+    background: rgba(255, 255, 255, 0.95);
+    padding: 1rem 2rem;
+    border-radius: 12px;
     backdrop-filter: blur(8px);
     -webkit-backdrop-filter: blur(8px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-    border-bottom: 1px solid rgba(226, 232, 240, 0.5);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+    border: 1px solid rgba(226, 232, 240, 0.5);
     text-align: center;
   }
   
   .overlay-title {
-    font-size: 2rem;
+    font-size: 1.5rem;
     font-weight: 700;
     color: var(--text-primary);
     margin: 0;
-  }
-  
-  .overlay-description {
-    transition: opacity 0.3s ease, max-height 0.3s ease;
-    overflow: hidden;
-    margin-top: 1rem;
-  }
-  
-  .overlay-description p {
-    font-size: 1rem;
-    color: var(--text-secondary);
-    line-height: 1.6;
-    margin: 0 auto;
-    max-width: 800px;
+    white-space: nowrap;
   }
   
   
@@ -1162,7 +1141,7 @@
     padding: 2rem 3rem 50vh 3rem;
     padding-left: calc(120px + 3rem); /* Space for y-axis - matches chart margin */
     padding-right: calc(120px + 3rem); /* Match left side for symmetry */
-    margin-top: 280px; /* Space for the fixed title overlay */
+    margin-top: 4rem; /* Normal spacing since title overlay is smaller */
     width: 100%;
     position: relative;
   }
@@ -1394,15 +1373,12 @@
     
     /* Mobile title overlay styles */
     .title-overlay {
-      padding: 1rem;
+      top: 1rem;
+      padding: 0.75rem 1.5rem;
     }
     
     .overlay-title {
-      font-size: 1.25rem;
-    }
-    
-    .overlay-description p {
-      font-size: 0.875rem;
+      font-size: 1.125rem;
     }
     
     .baseline-selector-overlay {
@@ -1429,7 +1405,7 @@
     .text-content {
       padding: 1rem 1rem 30vh 1rem;
       max-width: 100%;
-      margin-top: 200px; /* Space for mobile title overlay */
+      margin-top: 3rem; /* Less space needed on mobile */
     }
     
     .text-section {
@@ -1477,15 +1453,12 @@
   /* Small mobile devices */
   @media (max-width: 480px) {
     .title-overlay {
-      padding: 0.75rem;
+      top: 0.5rem;
+      padding: 0.5rem 1rem;
     }
     
     .overlay-title {
-      font-size: 1rem;
-    }
-    
-    .overlay-description p {
-      font-size: 0.813rem;
+      font-size: 0.875rem;
     }
     
     .baseline-selector-overlay {
@@ -1505,7 +1478,7 @@
     
     .text-content {
       padding: 0.75rem 0.75rem 20vh 0.75rem;
-      margin-top: 160px; /* Space for small mobile title overlay */
+      margin-top: 2.5rem;
     }
     
     .text-section {


### PR DESCRIPTION
## Summary
- Removed floating header component
- Implemented persistent title overlay
- Converted baseline selector to dropdown on mobile

## Changes
1. **Title Overlay**: Simple centered box with just the title, always visible
2. **Baseline Selector**: 
   - Desktop: Remains as inline selector in top-right overlay
   - Mobile: Converts to dropdown at bottom-right to avoid title overlap
3. **Intro Section**: No longer shows duplicate title, just description content
4. **Layout**: Increased top margin so second box appears centered when scrolled to

## Mobile Improvements
- Baseline selector now appears as a compact dropdown button
- Click to open menu with baseline options
- Positioned at bottom-right to avoid interfering with title
- Click outside to close dropdown

Fixes #109

🤖 Generated with [Claude Code](https://claude.ai/code)