### PR TITLE
Fix axis alignment issues when app is iframed

### DIFF
--- a/src/lib/components/ScatterPlot.svelte
+++ b/src/lib/components/ScatterPlot.svelte
@@ -415,13 +415,24 @@
   function handleResize() {
     if (canvasRef && svgRef) {
       const container = canvasRef.parentElement;
-      width = container.clientWidth;
-      height = container.clientHeight;
+      // Get the actual rendered dimensions
+      const rect = container.getBoundingClientRect();
+      width = Math.floor(rect.width);
+      height = Math.floor(rect.height);
       updateMargins(); // Update margins based on viewport
+      
+      // Set canvas resolution to match CSS size
       canvasRef.width = width;
       canvasRef.height = height;
+      canvasRef.style.width = width + 'px';
+      canvasRef.style.height = height + 'px';
+      
+      // Ensure SVG matches exactly
       svgRef.setAttribute('width', width);
       svgRef.setAttribute('height', height);
+      svgRef.style.width = width + 'px';
+      svgRef.style.height = height + 'px';
+      
       renderVisualization();
     }
   }
@@ -429,6 +440,14 @@
   onMount(() => {
     handleResize();
     window.addEventListener('resize', handleResize);
+    
+    // In iframe contexts, dimensions might settle after initial render
+    const isInIframe = window.self !== window.top;
+    if (isInIframe) {
+      // Double-check dimensions after a short delay
+      setTimeout(handleResize, 100);
+      setTimeout(handleResize, 300);
+    }
     
     return () => {
       window.removeEventListener('resize', handleResize);
@@ -464,8 +483,7 @@
   .main-canvas {
     background: var(--app-background);
     cursor: crosshair;
-    width: 100%;
-    height: 100%;
+    display: block;
   }
   
   .overlay-svg {
@@ -473,5 +491,6 @@
     top: 0;
     left: 0;
     pointer-events: none;
+    display: block;
   }
 </style>


### PR DESCRIPTION
## Summary
- Fixes x-axis and y-axis misalignment that occurs when the app is embedded in an iframe
- Ensures canvas and SVG overlay stay perfectly synchronized

## Changes
- Use `getBoundingClientRect()` instead of `clientWidth/clientHeight` for accurate dimension measurement
- Set explicit pixel dimensions on both canvas and SVG elements
- Remove percentage-based CSS sizing that conflicts with explicit dimensions
- Add delayed resize checks for iframe contexts where dimensions may settle after initial render
- Add `display: block` to prevent inline element spacing issues

## Test plan
- [ ] Test the app standalone (not in iframe) - axes should align correctly
- [ ] Test the app when embedded in an iframe - axes should now align correctly
- [ ] Test resizing the browser window in both contexts
- [ ] Test on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)